### PR TITLE
Update terminal.md

### DIFF
--- a/overview/codeanywhereui/terminal.md
+++ b/overview/codeanywhereui/terminal.md
@@ -68,5 +68,5 @@ Putty config:
 
 Now in order to connect to your box, you have to use the following command to create a tunnel from your local machine to your Container:
 ```sh
-ssh -P port cabox@preview.xxx.box.codeanywhere.com -i id_rsa.pub
+ssh -p port_number cabox@preview.xxx.box.codeanywhere.com -i ~/.ssh/id_rsa
 ```


### PR DESCRIPTION
Example previously said to use "-i id_rsa.pub" when it should use the "-i id_rsa" flag. User will get a "Permission denied (publickey)" error otherwise